### PR TITLE
asdf

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -71,7 +71,7 @@ jobs:
       # TODO: obtain dlsh from SheinbergLab, not benjamin-heasly
       - name: Install our dlsh libs and headers into the build environment.
         run: |
-          DLSH_VERSION=0.0.22
+          DLSH_VERSION=0.0.23
           wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
           sudo dpkg --install dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
 

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -68,11 +68,13 @@ jobs:
           sudo cmake --install build
 
       # TODO: obtain dlsh from SheinbergLab, not benjamin-heasly
-      - name: Install our dlsh libs and headers into the build environment.
+      - name: Install our dg and dlsh libs and headers into the build environment.
         run: |
-          DLSH_VERSION=0.0.23
-          wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
-          sudo dpkg --install dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
+          DLSH_VERSION=0.0.48
+          wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh-dg_${DLSH_VERSION}_$(dpkg --print-architecture).deb
+          wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh-dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
+          sudo dpkg --install dlsh-dg_${DLSH_VERSION}_$(dpkg --print-architecture).deb
+          sudo dpkg --install dlsh-dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
 
       - name: Build stim2 stimdlls, to include along with the stim2 executable.
         run: |
@@ -111,20 +113,6 @@ jobs:
         run: |
           wget ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}/stim2_${{ github.ref_name }}_$(dpkg --print-architecture).deb
           sudo apt install --yes ./stim2_${{ github.ref_name }}_$(dpkg --print-architecture).deb
-
-      # TODO: obtain dserv from SheinbergLab, not from benjamin-heasly.
-      - name: Install dserv along with the shared tcl 9 dependency.
-        run: |
-          DSERV_VERSION=0.0.48
-          wget https://github.com/benjamin-heasly/dserv/releases/download/${DSERV_VERSION}/dserv_${DSERV_VERSION}_$(dpkg --print-architecture).deb
-          sudo apt install --yes ./dserv_${DSERV_VERSION}_$(dpkg --print-architecture).deb
-
-      # TODO: obtain dlsh from SheinbergLab with a version, not from benjamin-heasly with "initial"
-      - name: Install our dlsh TCL utils and thier dependencies into the packaging dir.
-        run: |
-          mkdir -p /tmp/package/usr/local/dlsh
-          cd /tmp/package/usr/local/dlsh
-          wget https://github.com/benjamin-heasly/dlsh/releases/download/initial/dlsh.zip
 
       - name: Sanity check the installed package.
         run: |

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -61,8 +61,7 @@ jobs:
 
       - name: Install box2d v3 static lib into the build environment.
         run: |
-          git clone https://github.com/erincatto/box2d.git
-          cd box2d
+          cd deps/box2d
           mkdir build
           cmake -B build -D BOX2D_UNIT_TESTS=OFF -D BOX2D_SAMPLES=OFF -D BOX2D_BENCHMARKS=OFF -D BUILD_SHARED_LIBS=OFF
           cmake --build build --parallel

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -109,6 +109,13 @@ jobs:
 
     steps:
 
+      - name: Install TCL 9 to the sanity check environment.
+        run: |
+          cd deps/tcl/unix/
+          ./configure
+          make
+          sudo make install
+
       - name: Install the package we just released.
         run: |
           wget ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}/stim2_${{ github.ref_name }}_$(dpkg --print-architecture).deb

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -109,6 +109,11 @@ jobs:
 
     steps:
 
+      - name: Check out our stim2 code for the current tag.
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
       - name: Install TCL 9 to the sanity check environment.
         run: |
           cd deps/tcl/unix/

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -52,11 +52,12 @@ jobs:
           cmake --build . --config Release
           sudo make install
     
-      - name: Install our dlsh libs and headers into the build environment.
+      # TODO: obtain dlsh from SheinbergLab, not benjamin-heasly
+      - name: Install our dg and dlsh libs and headers into the build environment.
         run: |
-          DLSH_VERSION=0.9.6
-          wget https://github.com/sheinberglab/dlsh/releases/download/${DLSH_VERSION}/dlsh-${DLSH_VERSION}-Darwin-signed.pkg
-          sudo installer -pkg dlsh-${DLSH_VERSION}-Darwin-signed.pkg -target /
+          DLSH_VERSION=0.0.48
+          wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh-${DLSH_VERSION}-Darwin-$(uname -m)-signed.pkg
+          sudo installer -pkg dlsh-${DLSH_VERSION}-Darwin-$(uname -m)-signed.pkg -target /
 
       - name: Build our stimdlls to include within the stim2 app bundle.
         run: |

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Build Box2D from source and install
         run: |
-          git clone https://github.com/erincatto/box2d.git
-          cd box2d
+          cd deps/box2d
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Release -DBOX2D_BUILD_UNIT_TESTS=OFF -DBOX2D_BUILD_TESTBED=OFF -DBUILD_SHARED_LIBS=OFF ..
           cmake --build . --config Release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,22 +1,28 @@
 [submodule "lib/glfw"]
-	path = lib/glfw
-	url = https://github.com/glfw/glfw
-
+    path = lib/glfw
+    url = https://github.com/glfw/glfw
+    ignore = untracked
 [submodule "lib/sockpp"]
-        path = lib/sockpp
-        url = https://github.com/fpagliughu/sockpp
+    path = lib/sockpp
+    url = https://github.com/fpagliughu/sockpp
+    ignore = untracked
 [submodule "deps/glfw"]
-	path = deps/glfw
-	url = https://github.com/glfw/glfw
+    path = deps/glfw
+    url = https://github.com/glfw/glfw
+    ignore = untracked
 [submodule "deps/sockpp"]
-	path = deps/sockpp
-	url = https://github.com/fpagliughi/sockpp
+    path = deps/sockpp
+    url = https://github.com/fpagliughi/sockpp
+    ignore = untracked
 [submodule "tcl"]
-	path = deps/tcl
-	url = https://github.com/tcltk/tcl.git
+    path = deps/tcl
+    url = https://github.com/tcltk/tcl.git
+    ignore = untracked
 [submodule "deps/spine-runtimes"]
-	path = deps/spine-runtimes
-	url = https://github.com/EsotericSoftware/spine-runtimes.git
+    path = deps/spine-runtimes
+    url = https://github.com/EsotericSoftware/spine-runtimes.git
+    ignore = untracked
 [submodule "deps/box2d"]
-	path = deps/box2d
-	url = https://github.com/erincatto/box2d.git
+    path = deps/box2d
+    url = https://github.com/erincatto/box2d.git
+    ignore = untracked

--- a/scripts/docker/Dockerfile-run
+++ b/scripts/docker/Dockerfile-run
@@ -35,7 +35,3 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
-
-# Install our dlsh TCL utils and thier dependencies.
-WORKDIR /usr/local/dlsh
-RUN wget https://github.com/benjamin-heasly/dlsh/releases/download/initial/dlsh.zip

--- a/scripts/docker/Dockerfile-stimdlls
+++ b/scripts/docker/Dockerfile-stimdlls
@@ -52,10 +52,12 @@ RUN cmake -B build -D BOX2D_UNIT_TESTS=OFF -D BOX2D_SAMPLES=OFF -D BOX2D_BENCHMA
   && cmake --install build
 
 # Install our dlsh libs and headers into the build environment.
-ENV DLSH_VERSION=0.0.23
+ENV DLSH_VERSION=0.0.48
 WORKDIR /work/dlsh
-RUN wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh_${DLSH_VERSION}_amd64.deb \
-  && dpkg --install dlsh_${DLSH_VERSION}_amd64.deb
+RUN wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh-dg_${DLSH_VERSION}_$(dpkg --print-architecture).deb \
+  && wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh-dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb \
+  && dpkg --install dlsh-dg_${DLSH_VERSION}_$(dpkg --print-architecture).deb \
+  && dpkg --install dlsh-dlsh_${DLSH_VERSION}_$(dpkg --print-architecture).deb
 
 # Build stimdlls.
 WORKDIR /work/stim2/stimdlls

--- a/scripts/docker/Dockerfile-stimdlls
+++ b/scripts/docker/Dockerfile-stimdlls
@@ -52,7 +52,7 @@ RUN cmake -B build -D BOX2D_UNIT_TESTS=OFF -D BOX2D_SAMPLES=OFF -D BOX2D_BENCHMA
   && cmake --install build
 
 # Install our dlsh libs and headers into the build environment.
-ENV DLSH_VERSION=0.0.22
+ENV DLSH_VERSION=0.0.23
 WORKDIR /work/dlsh
 RUN wget https://github.com/benjamin-heasly/dlsh/releases/download/${DLSH_VERSION}/dlsh_${DLSH_VERSION}_amd64.deb \
   && dpkg --install dlsh_${DLSH_VERSION}_amd64.deb


### PR DESCRIPTION
Hi @sheinb --

This updates the stim2 build to use new CI artifacts from dlsh.

dg and dlsh libs now come in separate .deb artifacts.  This came about from separating the dlsh build into three separate components (dg, dlsh, and dlsh.zip).

Also building against the latest box2d, same as dlsh.